### PR TITLE
Removed import of OrderedDict (it was never used / isn't 2.6 compatible)

### DIFF
--- a/rant/generator.py
+++ b/rant/generator.py
@@ -5,7 +5,6 @@ import re
 import time
 import datetime
 import codecs
-from collections import OrderedDict
 from fnmatch import fnmatch
 from jinja2 import Environment, FileSystemLoader
 


### PR DESCRIPTION
collections.OrderedDict was first introduced in python2.7, and I'm running python2.6 so I removed the importing of this module (which wasn't used anyways)

The README now more accurately reads 2.6/2.7 compatibility
